### PR TITLE
Bugfix: added a refresh button for inactive accounts

### DIFF
--- a/macOS/Features/MessageDetail/MessageDetailView.swift
+++ b/macOS/Features/MessageDetail/MessageDetailView.swift
@@ -52,7 +52,8 @@ struct MessageDetailView: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .clipShape(RoundedRectangle(cornerRadius: 12))
                         .padding(24)
-                    if let account = selectedAccount, let attachments = selectedMessage.data.attachments, !attachments.isEmpty {
+                    let account = selectedAccount
+                    if let attachments = selectedMessage.data.attachments, !attachments.isEmpty {
                         AttachmentsView(controller: AttachmentsViewController(account: account, attachments: attachments))
                             .padding(.horizontal)
                     }

--- a/macOS/Features/Sidebar/AccountInfoView/AccountInfoView.swift
+++ b/macOS/Features/Sidebar/AccountInfoView/AccountInfoView.swift
@@ -12,6 +12,7 @@ struct AccountInfoView: View {
     var isActive: Bool
     var address: String
     var password: String
+    var refresh: () -> Void
     
     @StateObject var controller = AccountInfoViewController()
     @State var isPasswordVisible = false
@@ -37,6 +38,7 @@ struct AccountInfoView: View {
                         .padding()
                 }
             }
+            .padding(.bottom, 4)
             
             HStack {
                 KeyView(key: "Status")
@@ -45,6 +47,14 @@ struct AccountInfoView: View {
                     .foregroundColor(isActive ? .green : .red)
                 Text(isActive ? "Active" : "InActive")
                     .lineLimit(1)
+                if (!isActive) {
+                    Spacer()
+                    Button {
+                        refresh()
+                    } label: {
+                        Image(systemName: "arrow.clockwise.circle.fill")
+                    }
+                }
             }
             
             HStack {
@@ -52,12 +62,14 @@ struct AccountInfoView: View {
                 Text(address)
                     .lineLimit(1)
                 
+                Spacer()
+                
                 Button {
                     controller.copyStringToPasteboard(value: address)
                 } label: {
                     Image(systemName: "doc.on.doc.fill")
                 }
-                Spacer()
+                
             }
             
             HStack {
@@ -70,12 +82,14 @@ struct AccountInfoView: View {
                             isPasswordVisible = isHovering
                         }
                     }
+                
+                Spacer()
+                
                 Button {
                     controller.copyStringToPasteboard(value: password)
                 } label: {
                     Image(systemName: "doc.on.doc.fill")
                 }
-                Spacer()
             }
         }
         .padding()
@@ -102,12 +116,16 @@ struct AccountInfoView_Previews: PreviewProvider {
     static var previews: some View {
         AccountInfoView(isActive: true,
                         address: "Address",
-                        password: "Password")
-            .previewLayout(.fixed(width: 400, height: 500))
+                        password: "Password") {
+            print("Refresh...")
+        }
+        .previewLayout(.fixed(width: 400, height: 500))
         
         AccountInfoView(isActive: false,
                         address: "Address",
-                        password: "Password")
-            .previewLayout(.fixed(width: 400, height: 500))
+                        password: "Password") {
+            print("Refresh...")
+        }
+        .previewLayout(.fixed(width: 400, height: 500))
     }
 }

--- a/macOS/Features/Sidebar/SidebarView.swift
+++ b/macOS/Features/Sidebar/SidebarView.swift
@@ -40,7 +40,9 @@ struct SidebarView: View {
                 VStack {
                     AccountInfoView(isActive: appController.selectedAccountConnectionIsActive,
                                     address: selectedAccount.address,
-                                    password: selectedAccount.password)
+                                    password: selectedAccount.password) {
+                        appController.refreshAccount(account: selectedAccount)
+                    }
                         .padding(.horizontal)
                     QuotaView(value: selectedAccount.quotaUsed, total: selectedAccount.quotaLimit)
                         .padding()

--- a/macOS/Services/MessagesListenerService.swift
+++ b/macOS/Services/MessagesListenerService.swift
@@ -63,7 +63,7 @@ class MessagesListenerService {
             .store(in: &subscriptions)
     }
     
-    private func addChannelAndStartListening(account: Account) {
+    func addChannelAndStartListening(account: Account) {
         let messageListener = createListener(withToken: account.token, accountId: account.id)
         channels[account] = messageListener
         channelsStatus[account] = .closed
@@ -97,7 +97,7 @@ class MessagesListenerService {
         messageListener.start()
     }
     
-    private func stopListeningAndRemoveChannel(account: Account) {
+    func stopListeningAndRemoveChannel(account: Account) {
         if let existingListener = channels[account] {
             existingListener.stop()
             channels.removeValue(forKey: account)


### PR DESCRIPTION
### Task #31 
Inactive accounts are occurring due to invalid jwt tokens likely due to exceeding their expiry time
* Added a refresh button, in `AccountInfoView` for inactive accounts to expose a way to refetch a new jwt token
  * If successful the email will return to an active state & restart fetching for emails
  * if unsuccessful an alert box will be presented with the error

### Screenshot

#### Inactive 
![tempbox-inactive-account](https://github.com/devwaseem/TempBox/assets/17956461/942c16d7-9f86-421e-aa01-ddbdc61d08b3)

#### Active 
![tempbox-active-account](https://github.com/devwaseem/TempBox/assets/17956461/8202f81c-da9c-433e-8962-b01672dbf338)

